### PR TITLE
Create keep-alive.yaml

### DIFF
--- a/.github/keep-alive.yaml
+++ b/.github/keep-alive.yaml
@@ -1,0 +1,13 @@
+name: Dummy commit if no commit in last 50 days to keep GitHub Actions alive
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  cronjob-based-github-action:
+    name: Cronjob based github action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
Added GH Action to dummy commit if there is no commit in the last 50 days. This keeps GH Actions alive